### PR TITLE
Fix alpha_inf/alpha_eq normalisation and split alpha_hyd into local and configured components

### DIFF
--- a/src/transitionlistener/bubbledynamics.py
+++ b/src/transitionlistener/bubbledynamics.py
@@ -2069,22 +2069,21 @@ def calcAlphas(T: float, pot, high_phase, low_phase, verbose=False) -> tuple[flo
     m_bos_before = np.sqrt(np.where(m2_bos_before > 0, m2_bos_before, 0))
     delta_m_bos = np.maximum(m_bos_after - m_bos_before, 0)
 
-    alpha_hyd = []
-    include_decoupled_in_enthalpy = bool(pot.config.gwConf.coupled_hydrodynamics)
-    Veff_sym_w = pot.Vtot(high_phi, T, include_decoupled=include_decoupled_in_enthalpy) - V0_ref
-    e_sym_w = pot.energyDensity(high_phi, T, include_decoupled=include_decoupled_in_enthalpy)
-    alpha_hyd.append((theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w)))
+	# alpha_eq, see eq. (2.16) in 1903.09642
+	# the hydrodynamic alphas do not depend on the decoupled radiation bath!
+	Veff_sym_w = pot.Vtot(high_phi, T, include_decoupled=False) - V0_ref
+	e_sym_w = pot.energyDensity(high_phi, T, include_decoupled=False)
+	alpha_hyd_coupled = (theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w))
 
-    # alpha_eq, see eq. (2.16) in 1903.09642
-    # the hydrodynamic alphas do not depend on the decoupled radiation bath!
-    Veff_sym_w = pot.Vtot(high_phi, T, include_decoupled=False) - V0_ref
-    e_sym_w = pot.energyDensity(high_phi, T, include_decoupled=False)
-    alpha_hyd_decoupled = (theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w))
-    alpha_hyd.append(alpha_hyd_decoupled)
-    alpha_eq = T**3 / (3/4 * (-Veff_sym_w + e_sym_w)) * np.sum(delta_m_bos * gauge_coupling**2 * dof_bos * is_physical, axis=-1)
-    alpha_inf = T**2 / (18 * (-Veff_sym_w + e_sym_w)) * m2factor
+	alpha_eq = T**3 / (3/4 * (-Veff_sym_w + e_sym_w)) * np.sum(delta_m_bos * gauge_coupling**2 * dof_bos * is_physical, axis=-1)
+	alpha_inf = T**2 / (18 * (-Veff_sym_w + e_sym_w)) * m2factor
+	
+	include_decoupled_in_enthalpy = bool(pot.config.gwConf.coupled_hydrodynamics)
+	Veff_sym_w = pot.Vtot(high_phi, T, include_decoupled=include_decoupled_in_enthalpy) - V0_ref
+	e_sym_w = pot.energyDensity(high_phi, T, include_decoupled=include_decoupled_in_enthalpy)
+	alpha_hyd_config = (theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w))
 
-    return alpha_p, alpha_theta, alpha_thetabar, alpha_e, alpha_hyd, alpha_inf, alpha_eq
+	return alpha_p, alpha_theta, alpha_thetabar, alpha_e, [alpha_hyd_coupled, alpha_hyd_config], alpha_inf, alpha_eq
 
 
 

--- a/src/transitionlistener/bubbledynamics.py
+++ b/src/transitionlistener/bubbledynamics.py
@@ -2069,21 +2069,24 @@ def calcAlphas(T: float, pot, high_phase, low_phase, verbose=False) -> tuple[flo
     m_bos_before = np.sqrt(np.where(m2_bos_before > 0, m2_bos_before, 0))
     delta_m_bos = np.maximum(m_bos_after - m_bos_before, 0)
 
-    # alpha_eq, see eq. (2.16) in 1903.09642
-    # the hydrodynamic alphas do not depend on the decoupled radiation bath!
-    alpha_eq = T**3 / rho_rad_PTsector * np.sum(delta_m_bos * gauge_coupling**2 * dof_bos * is_physical, axis=-1)
-    alpha_inf = T**2 / (24 * rho_rad_PTsector) * m2factor
-
-    # alpha_hyd is the Giese-KKS strength fed to calc_kappas. Denominator is
-    # 3 * w_sym; w_sym must include the decoupled bath only when the two sectors
-    # are hydrodynamically coupled, otherwise the wall only does work on the PT
-    # sector.
+    alpha_hyd = []
     include_decoupled_in_enthalpy = bool(pot.config.gwConf.coupled_hydrodynamics)
     Veff_sym_w = pot.Vtot(high_phi, T, include_decoupled=include_decoupled_in_enthalpy) - V0_ref
     e_sym_w = pot.energyDensity(high_phi, T, include_decoupled=include_decoupled_in_enthalpy)
-    alpha_hyd = (theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w))
+    alpha_hyd.append((theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w)))
+
+    # alpha_eq, see eq. (2.16) in 1903.09642
+    # the hydrodynamic alphas do not depend on the decoupled radiation bath!
+    Veff_sym_w = pot.Vtot(high_phi, T, include_decoupled=False) - V0_ref
+    e_sym_w = pot.energyDensity(high_phi, T, include_decoupled=False)
+    alpha_hyd_decoupled = (theta_sym - theta_bro) / (3 * (-Veff_sym_w + e_sym_w))
+    alpha_hyd.append(alpha_hyd_decoupled)
+    alpha_eq = T**3 / (3/4 * (-Veff_sym_w + e_sym_w)) * np.sum(delta_m_bos * gauge_coupling**2 * dof_bos * is_physical, axis=-1)
+    alpha_inf = T**2 / (18 * (-Veff_sym_w + e_sym_w)) * m2factor
 
     return alpha_p, alpha_theta, alpha_thetabar, alpha_e, alpha_hyd, alpha_inf, alpha_eq
+
+
 
 
 def calc_betaH_S3_approx(T, outdict, pot, phase_sym, phase_bro, tmin, tmax, verbose=False):

--- a/src/transitionlistener/hydrodynamics.py
+++ b/src/transitionlistener/hydrodynamics.py
@@ -579,7 +579,7 @@ def calc_kappas(alphaN: float, alpha_inf: float, alpha_eq: float,
     Parameters
     ----------
     alphaN : float
-        alphaN = [alpha_hyd, alpha_hyd_decoupled] from bubbledynamics.py
+        alphaN = [alpha_hyd_coupled, alpha_hyd_config] from bubbledynamics.py
     alpha_inf : float
         The critical strength of the phase transition at which bubbles
         would run away if there was only leading order friction.

--- a/src/transitionlistener/hydrodynamics.py
+++ b/src/transitionlistener/hydrodynamics.py
@@ -579,7 +579,7 @@ def calc_kappas(alphaN: float, alpha_inf: float, alpha_eq: float,
     Parameters
     ----------
     alphaN : float
-        The strength of the phase transition at nucleation.
+        alphaN = [alpha_hyd, alpha_hyd_decoupled] from bubbledynamics.py
     alpha_inf : float
         The critical strength of the phase transition at which bubbles
         would run away if there was only leading order friction.
@@ -618,7 +618,7 @@ def calc_kappas(alphaN: float, alpha_inf: float, alpha_eq: float,
     # Computation of kappa_phi
     # based on 1903.09642 by John Ellis, Marek 
     # Lewicki, José Miguel No & Ville Vaskonen
-    gamma_eq = np.inf if alpha_eq == 0 else (alphaN - alpha_inf) / alpha_eq
+    gamma_eq = np.inf if alpha_eq == 0 else (alphaN[0] - alpha_inf) / alpha_eq
     gamma_star = 2 * Rsep / (3 * R0)
 
     def kappa_col(gamma_star, gamma_eq, alpha_inf, alpha):
@@ -637,7 +637,7 @@ def calc_kappas(alphaN: float, alpha_inf: float, alpha_eq: float,
     elif config.bw_collisions == "full":
         kappa_BW = 1
     elif config.bw_collisions == "NLO":
-        kappa_BW = kappa_col(gamma_star, gamma_eq, alpha_inf, alphaN)
+        kappa_BW = kappa_col(gamma_star, gamma_eq, alpha_inf, alphaN[0])
     else:
         raise ValueError("Wrong config input: bw_collisions must be 'off', 'full' or 'NLO'.")
 
@@ -646,7 +646,7 @@ def calc_kappas(alphaN: float, alpha_inf: float, alpha_eq: float,
     # based on  1004.4187 by Jose R. Espinosa, Thomas Konstandin,
     # Jose M. No & Geraldine Servant
 
-    alpha_eff = alphaN * (1 - kappa_BW)
+    alpha_eff = alphaN[1] * (1 - kappa_BW)
     kappa_SW = (1 - kappa_BW) * kappa_sw(alpha_eff, vw, cs)
     kappa_TURB = eps * kappa_SW
     return kappa_BW, kappa_SW, kappa_TURB


### PR DESCRIPTION
## Summary

This PR fixes the normalisation of $\alpha_{\infty}$ and $\alpha_{\rm eq}$, which are used to determine whether the bubble wall runs away.

Currently, $\alpha$ is normalised by the false-vacuum enthalpy $w_f$, while $\alpha_{\infty}$ and $\alpha_{\rm eq}$ are normalised by the radiation energy density $\rho_f^{\rm rad}$. This is inconsistent because these quantities are compared directly in the runaway condition.

This PR normalises $\alpha_{\infty}$ and $\alpha_{\rm eq}$ by $\tfrac34 w_f$, making the normalisation consistent with $\alpha$. It also distinguishes the hydrodynamic strength parameter used for the local wall-friction calculation from the one used for the macroscopic fluid-efficiency calculation.

The correction matters whenever the false vacuum contains non-relativistic degrees of freedom, for example in strongly supercooled or multi-step phase transitions.

## Why

The runaway condition compares $\alpha$ directly against $\alpha_{\infty}$ and $\alpha_{\rm eq}$. For this comparison to be physically meaningful, all three quantities must use the same normalisation.

Previously, $\alpha_{\infty},\alpha_{\rm eq}\propto \frac{1}{\rho_f^{\rm rad}}$ while $\alpha\propto \frac{1}{3w_f/4}$.

The equality $\frac34 w_f=\rho_f^{\rm rad}$ only holds in the fully relativistic limit. In the presence of non-relativistic degrees of freedom, $w_f$ differs from $\tfrac43\rho_f^{\rm rad}$, so using $\rho_f^{\rm rad}$ introduces an inconsistent normalisation.

This discrepancy can become relevant for instance for:

* strongly supercooled transitions, where $T_p$ is below the relevant zero-temperature mass scales;
* multi-step phase transitions with a non-trivial false vacuum, $\langle\phi\rangle_f\neq0$;
* portal-coupled spectator sectors whose masses remain non-relativistic in the false vacuum.

Using the enthalpy consistently generally increases $\alpha_{\infty}$ and $\alpha_{\rm eq}$ because $w_f\leq\frac43\rho_f^{\rm rad}$, which can modify the wall-velocity determination and the resulting efficiency factors and GW spectrum.

## Changes

### `bubbledynamics.py` — `calcAlphas`

The denominator of `alpha_inf` and `alpha_eq` is changed from `rho_rad_PTsector` to `3/4 * (-Veff_sym_w + e_sym_w)`, which corresponds to $\tfrac34w_f$.

Two hydrodynamic variants are also introduced:

* `alpha_hyd_coupled`: excludes the sector decoupled from the bubble field because it does not contribute directly to microscopic wall friction and is used for $\kappa_{\rm col}$;
* `alpha_hyd_config`: the original `alpha_hyd`, including or excluding the decoupled sector according to `include_decoupled_in_enthalpy`; used for $\kappa_{\rm sw}$ and $\kappa_{\rm turb}$, since these describe the macroscopic energy budget and therefore depend on the enthalpy of the hydrodynamically coupled bath;
* The final output is returned as `[alpha_hyd_coupled, alpha_hyd_config]`, instead of `alpha_hyd`

### `hydrodynamics.py` — `calc_kappas`

`calc_kappas` now receives `alphaN = [alpha_hyd_coupled, alpha_hyd_config]` instead of a single hydrodynamic strength parameter

```text
alphaN[0] -> kappa_BW
alphaN[1] -> kappa_sw, kappa_turb
```
This replaces the previous use of a single `alphaN` for all three efficiency factors.

## Effect on the calculation

The expected qualitative change is:

$\alpha_{\infty},\alpha_{\rm eq}\uparrow\quad\Longrightarrow\quad\kappa_{\rm col}\downarrow\quad\Longrightarrow\quad\kappa_{\rm sw},\kappa_{\rm turb}\uparrow$.

The size of the effect depends on how much non-relativistic matter is present in the false vacuum.

## Testing

I tested the change in the already-implemented dark flip-flop model using the benchmark point

```text
lambda0, lambda1, lambda12, v_GeV, y, gamma = 0.02432, 0.014524, 0.023401, 0.927, 1.0, 1.0
```
from Table 2 of [[2602.09092](https://arxiv.org/pdf/2602.09092)]. This benchmark point realises a two-step phase transition in which the second step is first order.

In this model there is no gauge boson coupled to the dark scalar sector, so $\alpha_{\rm eq}=0$, and the wall dynamics are controlled by the leading-order Bödeker–Moore friction through $\kappa_{\rm col}=1-\frac{\alpha_{\infty}}{\alpha}$.

Compared with the original implementation:

* $\alpha_{\infty}$ changes by approximately 4%;
* the change comes from the false-vacuum contribution of the single dark scalar $\phi_2$, which was not captured by the previous $\phi_f=0$-based normalisation;
* $\kappa_{\rm col}$ changes by only approximately 0.01%.

The small change in $\kappa_{\rm col}$ is expected for this benchmark point. The correction to $\alpha_{\infty}$ is itself modest, and we are already deep in the runaway regime, with $\alpha_{\infty}/\alpha\approx0.25$%. Therefore the response of $\kappa_{\rm col}$ to changes in $\alpha_{\infty}$ is strongly suppressed.

This suppression is benchmark-specific and should not be interpreted as evidence that the correction is generally negligible. In particular, models containing gauge bosons or Yukawa-coupled fermions whose masses are generated directly by the transitioning field at the false vacuum can produce substantially larger corrections to $\alpha_{\infty}$ and/or $\alpha_{\rm eq}$. When $\alpha_{\rm eq}\neq0$ and $\gamma_\star>\gamma_{\rm eq}$, the dependence on $\alpha_{\rm eq}$ can enter $\kappa_{\rm col}$ at leading order rather than through the small $\alpha_{\infty}/\alpha$ prefactor.

## Impact / backward compatibility

There are two changes that can affect the results:

* Normalisation of $\alpha_{\infty}$ and $\alpha_{\rm eq}$: the new normalisation reduces to the previous one in the relativistic limit, $\frac34 w_f=\rho_f^{\rm rad}$. Thus, results are unchanged by this part of the fix when the relativistic limit is applicable.

* Local vs. configured $\alpha_{\rm hyd}$: the new `alpha_hyd_coupled` / `alpha_hyd_config` distinction reduces to the previous single-alphaN treatment when there is no decoupled sector, since in that case `alpha_hyd_coupled` =  `alpha_hyd_config`.

Therefore, the full calculation reproduces the previous implementation when both conditions are satisfied: the false-vacuum enthalpy satisfies $\frac34 w_f=\rho_f^{\rm rad}$ and there is no decoupled sector.

Results can differ for models with non-relativistic degrees of freedom in the false vacuum and/or a decoupled sector. In affected models, $\alpha_{\infty}$ and/or $\alpha_{\rm eq}$ are generally strengthened by the new normalisation, while the distinction between local and configured $\alpha_{\rm hyd}$ changes the hydrodynamic efficiency calculation.
